### PR TITLE
add clientTokenAttributeMap property

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $token = Yii::$app->tokenManager->getToken();
 if you need to map attributes from within the token to "other" clientAttributes, this can be done via the `clientTokenAttributeMap` property.
 
 Example: 
-The user id in the token is named `sub` but should be mapped to the `id` attribute
+The user id in the keycloak token is named `sub` but must be mapped to the `id` attribute
 
 ```php
 'bootstrap' => [
@@ -88,7 +88,7 @@ The user id in the token is named `sub` but should be mapped to the `id` attribu
         'clientClientId' => getenv('KEYCLOAK_CLIENT'),
         'clientClientSecret' => getenv('KEYCLOAK_CLIENT_SECRET'),
         'clientTokenAttributeMap' => [
-                'id' => 'sub'
+                'sub' => 'id'
          ],
     ]
 ],

--- a/README.md
+++ b/README.md
@@ -71,3 +71,26 @@ use dmstr\tokenManager\components\TokenManager;
 
 $token = Yii::$app->tokenManager->getToken();
 ```
+
+#### Token attribute mapping
+
+if you need to map attributes from within the token to "other" clientAttributes, this can be done via the `clientTokenAttributeMap` property.
+
+Example: 
+The user id in the token is named `sub` but should be mapped to the `id` attribute
+
+```php
+'bootstrap' => [
+    [
+        'class' => Bootstrap::class,
+        'clientAuthUrl' => getenv('KEYCLOAK_AUTH_URL'),
+        'clientIssuerUrl' => getenv('KEYCLOAK_ISSUER_URL'),
+        'clientClientId' => getenv('KEYCLOAK_CLIENT'),
+        'clientClientSecret' => getenv('KEYCLOAK_CLIENT_SECRET'),
+        'clientTokenAttributeMap' => [
+                'id' => 'sub'
+         ],
+    ]
+],
+
+```

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -30,7 +30,7 @@ class Bootstrap implements BootstrapInterface
     public string $clientIssuerUrl;
     public string $clientClientId;
     public string $clientClientSecret;
-
+    public array $clientTokenAttributeMap = [];
     public string $jwtComponentId = 'jwt';
     public string $tokenManagerComponentId = 'tokenManager';
 
@@ -56,7 +56,8 @@ class Bootstrap implements BootstrapInterface
             'clientId' => $this->clientClientId,
             'clientSecret' => $this->clientClientSecret,
             'name' => $this->clientName,
-            'title' => $this->clientTitle
+            'title' => $this->clientTitle,
+            'clientTokenAttributeMap' => $this->clientTokenAttributeMap
         ];
         $app->authClientCollection->setClients($clients);
 

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -30,6 +30,13 @@ class Bootstrap implements BootstrapInterface
     public string $clientIssuerUrl;
     public string $clientClientId;
     public string $clientClientSecret;
+
+    /**
+     * array of src -> dst attribute names that should be mapped from token (src)
+     * to dst key in clients\Keycloak::initUserAttributes
+     *
+     * @var array
+     */
     public array $clientTokenAttributeMap = [];
     public string $jwtComponentId = 'jwt';
     public string $tokenManagerComponentId = 'tokenManager';

--- a/src/clients/Keycloak.php
+++ b/src/clients/Keycloak.php
@@ -25,9 +25,9 @@ class Keycloak extends OpenIdConnect implements AuthClientInterface
         $loaded = $this->loadJws($token);
 
         if (is_array($this->clientTokenAttributeMap)) {
-            foreach ($this->clientTokenAttributeMap as $key => $src) {
-                if (empty($loaded[$key])) {
-                    $loaded[$key] = $loaded[$src] ?? null;
+            foreach ($this->clientTokenAttributeMap as $src => $dst) {
+                if (empty($loaded[$dst])) {
+                    $loaded[$dst] = $loaded[$src] ?? null;
                 }
             }
         }

--- a/src/clients/Keycloak.php
+++ b/src/clients/Keycloak.php
@@ -27,7 +27,7 @@ class Keycloak extends OpenIdConnect implements AuthClientInterface
         if (is_array($this->clientTokenAttributeMap)) {
             foreach ($this->clientTokenAttributeMap as $key => $src) {
                 if (empty($loaded[$key])) {
-                    $loaded[$key] = $loaded[$src];
+                    $loaded[$key] = $loaded[$src] ?? null;
                 }
             }
         }

--- a/src/clients/Keycloak.php
+++ b/src/clients/Keycloak.php
@@ -13,13 +13,25 @@ use yii\web\HttpException;
  */
 class Keycloak extends OpenIdConnect implements AuthClientInterface
 {
+
+    public $clientTokenAttributeMap = [];
+
     /**
      * {@inheritdoc}
      */
     protected function initUserAttributes()
     {
         $token = $this->getAccessToken()->getToken();
-        return $this->loadJws($token);
+        $loaded = $this->loadJws($token);
+
+        if (is_array($this->clientTokenAttributeMap)) {
+            foreach ($this->clientTokenAttributeMap as $key => $src) {
+                if (empty($loaded[$key])) {
+                    $loaded[$key] = $loaded[$src];
+                }
+            }
+        }
+        return $loaded;
     }
 
     /**
@@ -38,6 +50,7 @@ class Keycloak extends OpenIdConnect implements AuthClientInterface
         // returns the e-mail as it corresponds with the username
         return $this->getEmail();
     }
+
 
     /**
      * @throws HttpException


### PR DESCRIPTION
This PR adds a new `clientTokenAttributeMap` property to the `Bootstrap` and `Keycloak` class.

**Usecase**:
The user `id` in the token is named `sub` but must be mapped to the `id` attribute.

This can be done with the new `clientTokenAttributeMap` property now.

```php
'bootstrap' => [
    [
        'class' => Bootstrap::class,
        'clientAuthUrl' => getenv('KEYCLOAK_AUTH_URL'),
        'clientIssuerUrl' => getenv('KEYCLOAK_ISSUER_URL'),
        'clientClientId' => getenv('KEYCLOAK_CLIENT'),
        'clientClientSecret' => getenv('KEYCLOAK_CLIENT_SECRET'),
        'clientTokenAttributeMap' => [
                'id' => 'sub'
         ],
    ]
],

```